### PR TITLE
Update install.php

### DIFF
--- a/pages/install.php
+++ b/pages/install.php
@@ -22,6 +22,16 @@ if (rex_post('install', 'boolean')) {
 $content = '<p>' . $this->i18n('install_description') . '</p>';
 $content .= '<p><button class="btn btn-send" type="submit" name="install" value="1"><i class="rex-icon fa-download"></i> ' . $this->i18n('install_button') . '</button></p>';
 
+// Hinweis auf YRewrite / .htaccess
+$content .= '
+<p>
+Zum Abschluß der Installation muss durch YRewrite noch eine .htaccess-Datei im Root-Ordner erstellt werden. Dies erfolgt über das Setup des YRewrite-AddOns.
+</p>
+';
+$content .= '
+<p><a class="btn btn-primary" href="'.rex_url::backendPage('yrewrite/setup').'">YRewrite Setup aufrufen</a></p>
+';
+
 $fragment = new rex_fragment();
 $fragment->setVar('title', $this->i18n('install_heading'), false);
 $fragment->setVar('body', $content, false);


### PR DESCRIPTION
Hinweis auf YRewrite-Setup

Der Schritt des Setzens der .htaccess-Datei fehlt noch zum Abschluß der Installation.

Es wäre auch möglich, das Setzen der .htaccess direkt anzustoßen (anstatt auf das YRewrite-Setup zu verweisen) durch einbinden des Buttons:

```
$csrf = rex_csrf_token::factory('yrewrite_setup');
$content .= '
<p><a class="btn btn-primary" href="'.rex_url::backendPage('yrewrite/setup',['func' => 'htaccess'] + $csrf->getUrlParams()).'">' . $this->i18n('yrewrite_htaccess_set') . '</a></p>
';
```

Allerdings wäre das Einbinden des Buttons damit verbunden, bei Änderungen im YRewrite an dieser Stelle immer rechtzeitig darauf zu reagieren und Anpassungen zu übernehmen.
